### PR TITLE
Replace limited dissolve operator with standard blender command

### DIFF
--- a/Wazou_Pie_Menus
+++ b/Wazou_Pie_Menus
@@ -2401,7 +2401,7 @@ class PieDelete(Menu):
         #1 - BOTTOM - LEFT
         box = pie.split().column()
         row = box.row(align=True)
-        box.operator("delete.limiteddissolve", text="Limited Dissolve", icon= 'STICKY_UVS_LOC')
+        box.operator("mesh.dissolve_limited", text="Limited Dissolve", icon= 'STICKY_UVS_LOC')
         box.operator("mesh.delete_edgeloop", text="Delete Edge Loops", icon='BORDER_LASSO')
         box.operator("mesh.edge_collapse", text="Edge Collapse", icon='UV_EDGESEL')
         #3 - BOTTOM - RIGHT


### PR DESCRIPTION
Hello,

first off thanks for your great addons and videos! They really made me change my workflow for the better.
I have a small problem with your otherwise great pie menu addon. The limited dissolve operator which gets triggered dissolves too much and gives no options in the operator panel after the operation. To solve this I changed it back to use the standard blender limited dissolve operator.

Maybe I misunderstood how the custom operator is supposed to work and if so just close this PR.

Thanks 
